### PR TITLE
added is-package

### DIFF
--- a/ft2/src/insertable.rs
+++ b/ft2/src/insertable.rs
@@ -65,6 +65,7 @@ pub struct Site {
     pub is_static: bool,
     pub is_public: bool,
     pub is_editable: bool,
+    pub is_package: bool,
     pub domain: String,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,

--- a/ft2/src/route/myself/create_site.rs
+++ b/ft2/src/route/myself/create_site.rs
@@ -61,6 +61,7 @@ impl ft_sdk::Action<ft2::route::MySelf, ft2::ActionError> for CreateSite {
                     is_static: true,
                     is_public: true,
                     is_editable: true,
+                    is_package: false,
                     domain: site_default_domain.clone(),
                     created_at: i.in_.now,
                     updated_at: i.in_.now,


### PR DESCRIPTION
Once https://github.com/FifthTry/ft/pull/136 is deployed, create-site on www.fifthtry.com will stop working this PR is merged. This PR can not be deployed before https://github.com/FifthTry/ft/pull/136 is deployed as it depends on a column that is being added in that PR. 

Maybe we update the migration of that PR so it becomes backward compatible (old create-site keeps working). We will have to make the column nullable. 